### PR TITLE
build(email-validator): move email-validator package to dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4814,10 +4814,9 @@
       "dev": true
     },
     "email-validator": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.0.tgz",
-      "integrity": "sha512-V8+WoNdHz/JJEOQMtF5/6TCYm6gJUmLCmwgsxEmB1lp3Wx2DxUrzp19BgEB5YHCi0UmNGFW7OdyxXSKfveCffA==",
-      "dev": true
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
+      "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ=="
     },
     "env-ci": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -46,9 +46,8 @@
       "<rootDir>/node_modules/"
     ]
   },
-  "dependencies": {},
-  "peerDependencies": {
-    "email-validator": "^2.0.0"
+  "dependencies": {
+    "email-validator": "^2.0.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.47",
@@ -61,7 +60,6 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.0.0",
     "codecov": "^3.0.2",
-    "email-validator": "^2.0.0",
     "eslint": "^5.0.0",
     "eslint-config-airbnb-base": "^13.0.0",
     "eslint-plugin-import": "^2.13.0",


### PR DESCRIPTION
BREAKING CHANGE: Move the email-validator package to dependency. rollup.js will automatically not bundle email-validator. However, by adding the email-validator as a direct dependency, the email-validator package will be automatically installed when email-prop-type is installed.

Resolves #41 